### PR TITLE
Bugfix for when initial scrollTop is > 0

### DIFF
--- a/jQuery.scrollSpeed.js
+++ b/jQuery.scrollSpeed.js
@@ -11,7 +11,7 @@
             $window = $(window),
             $body = $('html, body'),
             option = easing || 'default',
-            root = 0,
+            root = $(window).scrollTop() || 0,
             scroll = false,
             scrollY,
             scrollX,


### PR DESCRIPTION
When scroll position on page load is greater than zero (i.e. if you scroll to the middle of the page and reload it) the page would jump to the top on the first scroll, so you'd have to scroll all the way down again. It also happens if you click on anchors before the first scroll. Happens only once, but can be quite annoying.